### PR TITLE
feat:Like

### DIFF
--- a/src/components/InfiniteSpitsList.tsx
+++ b/src/components/InfiniteSpitsList.tsx
@@ -4,6 +4,7 @@ import { ProfileImage } from "./ProfileImage";
 import { useSession } from "next-auth/react";
 import { VscHeartFilled, VscHeart } from "react-icons/vsc";
 import { IconHoverEffect } from "./IconHoverEffect";
+import { api } from "~/utils/api";
 
 type Spit = {
   id: string;
@@ -67,6 +68,12 @@ function SpitCard({
   likeCount,
   likedByMe,
 }: Spit) {
+  const toggleLike = api.spit.toggleLike.useMutation();
+
+  function handleToggleLike() {
+    toggleLike.mutate({ id });
+  }
+
   return (
     <li className="flex gap-4 border-b px-4 py-4">
       <Link href={`/profiles/${user.id}`}>
@@ -86,18 +93,30 @@ function SpitCard({
           </span>
         </div>
         <p className="whitespace-pre-wrap">{content}</p>
-        <HeartButton likedByMe={likedByMe} likeCount={likeCount} />
+        <HeartButton
+          onClick={handleToggleLike}
+          isLoading={toggleLike.isLoading}
+          likedByMe={likedByMe}
+          likeCount={likeCount}
+        />
       </div>
     </li>
   );
 }
 
 type HeartButtonProps = {
+  onClick: () => void;
+  isLoading: boolean;
   likedByMe: boolean;
   likeCount: number;
 };
 
-function HeartButton({ likedByMe, likeCount }: HeartButtonProps) {
+function HeartButton({
+  isLoading,
+  onClick,
+  likedByMe,
+  likeCount,
+}: HeartButtonProps) {
   const session = useSession();
   const HeartIcon = likedByMe ? VscHeartFilled : VscHeart;
 
@@ -111,6 +130,8 @@ function HeartButton({ likedByMe, likeCount }: HeartButtonProps) {
   }
   return (
     <button
+      disabled={isLoading}
+      onClick={onClick}
       className={`group -ml-2 flex items-center gap-1 self-start transition-colors duration-200 ${
         likedByMe
           ? "text-red-500"

--- a/src/server/api/routers/spit.ts
+++ b/src/server/api/routers/spit.ts
@@ -71,4 +71,21 @@ export const spitRouter = createTRPCRouter({
 
       return spit;
     }),
+
+  toggleLike: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input: { id }, ctx }) => {
+      const data = { spitId: id, userId: ctx.session.user.id };
+      const existingLike = await ctx.prisma.like.findUnique({
+        where: { userId_spitId: data },
+      });
+
+      if (existingLike == null) {
+        await ctx.prisma.like.create({ data });
+        return { addedLike: true };
+      } else {
+        await ctx.prisma.like.delete({ where: { userId_spitId: data } });
+        return { addedLike: false };
+      }
+    }),
 });


### PR DESCRIPTION
This adds a like feature. It passes the user context's id into the like category within the DB and represents it with a red heart. We will likely change this to a spit droplet in the future.